### PR TITLE
Fix compiling on Linux

### DIFF
--- a/src/lang/processors/packages/mock_loader.h
+++ b/src/lang/processors/packages/mock_loader.h
@@ -9,6 +9,7 @@
 #ifndef lang_packages_mock_loader_h
 #define lang_packages_mock_loader_h
 
+#include <memory>
 #include <unordered_map>
 
 #include "src/lang/processors/packages/loader.h"

--- a/src/lang/processors/type_checker/coordinator.h
+++ b/src/lang/processors/type_checker/coordinator.h
@@ -9,6 +9,7 @@
 #ifndef lang_type_checker_coordinator_h
 #define lang_type_checker_coordinator_h
 
+#include <functional>
 #include <memory>
 #include <unordered_set>
 #include <vector>

--- a/src/lang/processors/type_checker/expr_handler.cc
+++ b/src/lang/processors/type_checker/expr_handler.cc
@@ -1145,7 +1145,7 @@ bool ExprHandler::CheckBasicLit(ast::BasicLit* basic_lit) {
   switch (basic_lit->kind()) {
     case tokens::kInt:
       type = info()->basic_type(types::Basic::kUntypedInt);
-      value = constants::Value(common::Int(std::stoll(basic_lit->value())));
+      value = constants::Value(common::Int(static_cast<int64_t>(std::stoll(basic_lit->value()))));
       break;
     case tokens::kChar:
       // TODO: support UTF-8 and character literals

--- a/src/main.cc
+++ b/src/main.cc
@@ -69,7 +69,7 @@ struct LoadResult {
   int exit_code;
 };
 
-LoadResult load(const std::vector<const std::string> args, std::ostream& err) {
+LoadResult load(const std::vector<std::string> args, std::ostream& err) {
   enum class ArgsKind {
     kNone,
     kMainPackageDirectory,
@@ -193,7 +193,7 @@ LoadResult load(const std::vector<const std::string> args, std::ostream& err) {
   };
 }
 
-int doc(const std::vector<const std::string> args, std::ostream& err) {
+int doc(const std::vector<std::string> args, std::ostream& err) {
   auto [pkg_manager, arg_pkgs, generate_debug_info, exit_code] = load(args, err);
   if (exit_code) {
     return exit_code;
@@ -221,7 +221,7 @@ struct BuildResult {
   int exit_code;
 };
 
-BuildResult build(const std::vector<const std::string> args, std::ostream& err) {
+BuildResult build(const std::vector<std::string> args, std::ostream& err) {
   auto [pkg_manager, arg_pkgs, generate_debug_info, exit_code] = load(args, err);
   if (exit_code) {
     return BuildResult{
@@ -340,7 +340,7 @@ BuildResult build(const std::vector<const std::string> args, std::ostream& err) 
   };
 }
 
-int run(const std::vector<const std::string> args, std::istream& in, std::ostream& out,
+int run(const std::vector<std::string> args, std::istream& in, std::ostream& out,
         std::ostream& err) {
   auto [ir_program, x86_64_program, exit_code] = build(args, err);
   if (exit_code) {
@@ -384,11 +384,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   std::string command(argv[1]);
-  std::vector<const std::string> args;
-  args.reserve(argc - 2);
-  for (int i = 2; i < argc; i++) {
-    args.push_back(std::string(argv[i]));
-  }
+  std::vector<std::string> args(argv + 1, argv + argc);
 
   if (command == "build") {
     return build(args, std::cerr).exit_code;


### PR DESCRIPTION
### Testing
CC=clang CXX=clang++ bazel run //src:katara
CC=clang CXX=clang++ bazel test //src/...

Only failure is syscall in execution_test.cc (segfault)

### Notez
https://stackoverflow.com/questions/6954906/does-c11-allow-vectorconst-t
